### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # MCP TaskManager
+[![smithery badge](https://smithery.ai/badge/@kazuph/mcp-taskmanager)](https://smithery.ai/server/@kazuph/mcp-taskmanager)
 
 Model Context Protocol server for Task Management. This allows Claude Desktop (or any MCP client) to manage and execute tasks in a queue-based system.
 
@@ -38,6 +39,14 @@ You can find this through the Claude Desktop menu:
 - Node.js 18+ (install via `brew install node`)
 - Claude Desktop (install from https://claude.ai/desktop)
 - tsx (install via `npm install -g tsx`)
+
+### Installing via Smithery
+
+To install TaskManager for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@kazuph/mcp-taskmanager):
+
+```bash
+npx -y @smithery/cli install @kazuph/mcp-taskmanager --client claude
+```
 
 ### Installation
 


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install TaskManager for Claude Desktop using Smithery CLI. This provides a convenient method for users to install the MCP seamlessly.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/@kazuph/mcp-taskmanager

Let me know if any tweaks have to be made!